### PR TITLE
Implement search form

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -3,11 +3,10 @@ import styles from "./index.module.scss";
 
 export type Props = {
   onChange: (_: any) => void;
-  register?: () => void;
   min?: string;
 };
 
-export const DatePicker: React.FC<Props> = ({ onChange, register, min }) => {
+export const DatePicker: React.FC<Props> = ({ onChange, min }) => {
   return (
     <div className={styles.myForm}>
       開催日{" "}
@@ -15,7 +14,6 @@ export const DatePicker: React.FC<Props> = ({ onChange, register, min }) => {
         className={styles.myFormInput}
         type="date"
         name="date"
-        ref={register}
         onChange={onChange}
         min={min}
       />

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./index.module.scss";
 
-export type Props = {
+type Props = {
   onChange: (_: any) => void;
   min?: string;
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,9 +3,10 @@ import styles from "./index.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { SearchForm } from "../SearchForm";
+import { OnSearch } from "../../containers/Main";
 
-export type Props = {
-  onSearch: (_: any) => void;
+type Props = {
+  onSearch: OnSearch;
 };
 
 export const Header: React.FC<Props> = ({ onSearch }) => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,20 +11,22 @@ type Props = {
 
 export const Header: React.FC<Props> = ({ onSearch }) => {
   const [showForm, onToggle] = useState(false);
+  const toggleForm = () => {
+    onToggle(prev => (prev ? false : true));
+  };
 
   return (
     <div>
       <div className={styles.myHeader}>
         <div className={styles.myHeaderTitle}>terakoya</div>
-        <div
-          className={styles.myHeaderSearch}
-          onClick={() => onToggle(prev => (prev ? false : true))}
-        >
+        <div className={styles.myHeaderSearch} onClick={toggleForm}>
           <FontAwesomeIcon icon={faSearch} />
         </div>
       </div>
       <div className={styles.myForm}>
-        {showForm ? <SearchForm onSearch={onSearch}></SearchForm> : null}
+        {showForm ? (
+          <SearchForm onSearch={onSearch} toggleForm={toggleForm}></SearchForm>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/ListHeader/index.tsx
+++ b/src/components/ListHeader/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./index.module.scss";
 
-export type Props = {
+type Props = {
   date: string;
 };
 

--- a/src/components/ListItem/index.tsx
+++ b/src/components/ListItem/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./index.module.scss";
 
-export type Props = {
+type Props = {
   title: string;
   address: string;
   startTime: string;

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import styles from "./index.module.scss";
 import { Header } from "../Header";
 import { EventList, EventListProps } from "../EventList";
+import { OnSearch } from "../../containers/Main";
 
-export type Props = {
-  onSearch: (_: any) => void;
+type Props = {
+  onSearch: OnSearch;
   events: EventListProps[];
 };
 

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useForm } from "react-hook-form";
+import React, { useReducer } from "react";
 import styles from "./index.module.scss";
 import { DatePicker } from "../DatePicker";
 
@@ -7,15 +6,37 @@ export type Props = {
   onSearch: (_: any) => void;
 };
 
+type State = {
+  date: string;
+};
+
+const initialState: State = {
+  date: ""
+};
+
+const reducer = (state: State, { field, value }: any) => {
+  return {
+    ...state,
+    [field]: value
+  };
+};
+
 export const SearchForm: React.FC<Props> = ({ onSearch }) => {
-  const { handleSubmit, register } = useForm();
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const onChange = (event: { target: { name: string; value: string } }) => {
+    dispatch({ field: event.target.name, value: event.target.value });
+  };
 
   return (
-    <div>
-      <form className={styles.myForm} onSubmit={handleSubmit(onSearch)}>
-        <DatePicker onChange={() => {}} register={register}></DatePicker>
-        <input className={styles.myFormButton} type="submit" value="検索する" />
-      </form>
+    <div className={styles.myForm}>
+      <DatePicker onChange={onChange}></DatePicker>
+      <button
+        className={styles.myFormButton}
+        type="button"
+        onClick={() => onSearch(state)}
+      >
+        検索する
+      </button>
     </div>
   );
 };

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -1,29 +1,29 @@
 import React, { useReducer } from "react";
 import styles from "./index.module.scss";
 import { DatePicker } from "../DatePicker";
+import { OnSearch, SearchFormData } from "../../containers/Main";
 
-export type Props = {
-  onSearch: (_: any) => void;
+type Props = {
+  onSearch: OnSearch;
 };
 
-type State = {
-  date: string;
-};
-
-const initialState: State = {
+const initialFormData: SearchFormData = {
   date: ""
 };
 
-const reducer = (state: State, { field, value }: any) => {
+const reducer = (
+  searchFormData: SearchFormData,
+  { field, value }: { field: string; value: string }
+) => {
   return {
-    ...state,
+    ...searchFormData,
     [field]: value
   };
 };
 
 export const SearchForm: React.FC<Props> = ({ onSearch }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const onChange = (event: { target: { name: string; value: string } }) => {
+  const [searchFormData, dispatch] = useReducer(reducer, initialFormData);
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({ field: event.target.name, value: event.target.value });
   };
 
@@ -33,7 +33,7 @@ export const SearchForm: React.FC<Props> = ({ onSearch }) => {
       <button
         className={styles.myFormButton}
         type="button"
-        onClick={() => onSearch(state)}
+        onClick={() => onSearch(searchFormData)}
       >
         検索する
       </button>

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -8,18 +8,30 @@ type Props = {
   toggleForm?: () => void;
 };
 
+type Action = {
+  type: "UPDATE";
+  payload: {
+    field: string;
+    value: string;
+  };
+};
+
 const initialFormData: SearchFormData = {
   date: ""
 };
 
-const reducer = (
-  prevFormData: SearchFormData,
-  { field, value }: { field: string; value: string }
-) => {
-  return {
-    ...prevFormData,
-    [field]: value
-  };
+const reducer = (prevFormData: SearchFormData, action: Action) => {
+  switch (action.type) {
+    case "UPDATE": {
+      const { payload } = action;
+      return {
+        ...prevFormData,
+        [payload.field]: payload.value
+      };
+    }
+    default:
+      return prevFormData;
+  }
 };
 
 export const SearchForm: React.FC<Props> = ({
@@ -28,7 +40,13 @@ export const SearchForm: React.FC<Props> = ({
 }) => {
   const [searchFormData, dispatch] = useReducer(reducer, initialFormData);
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch({ field: event.target.name, value: event.target.value });
+    dispatch({
+      type: "UPDATE",
+      payload: {
+        field: event.target.name,
+        value: event.target.value
+      }
+    });
   };
 
   return (

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -13,11 +13,11 @@ const initialFormData: SearchFormData = {
 };
 
 const reducer = (
-  searchFormData: SearchFormData,
+  prevFormData: SearchFormData,
   { field, value }: { field: string; value: string }
 ) => {
   return {
-    ...searchFormData,
+    ...prevFormData,
     [field]: value
   };
 };

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -5,6 +5,7 @@ import { OnSearch, SearchFormData } from "../../containers/Main";
 
 type Props = {
   onSearch: OnSearch;
+  toggleForm?: () => void;
 };
 
 const initialFormData: SearchFormData = {
@@ -21,7 +22,10 @@ const reducer = (
   };
 };
 
-export const SearchForm: React.FC<Props> = ({ onSearch }) => {
+export const SearchForm: React.FC<Props> = ({
+  onSearch,
+  toggleForm = () => {}
+}) => {
   const [searchFormData, dispatch] = useReducer(reducer, initialFormData);
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({ field: event.target.name, value: event.target.value });
@@ -33,7 +37,10 @@ export const SearchForm: React.FC<Props> = ({ onSearch }) => {
       <button
         className={styles.myFormButton}
         type="button"
-        onClick={() => onSearch(searchFormData)}
+        onClick={() => {
+          onSearch(searchFormData);
+          toggleForm();
+        }}
       >
         検索する
       </button>

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -8,8 +8,8 @@ const eventsApiEndpoint = "/api/events";
 
 export const Main = () => {
   const [events, setEvents] = useState<Event[]>([]);
-  const onSearch = () => {
-    return console.log("onSearch!");
+  const onSearch = (data: any) => {
+    return console.log(data);
   };
 
   useEffect(() => {

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -2,13 +2,18 @@ import React, { useEffect, useState } from "react";
 import { Main as MainComponent } from "../components/Main";
 import { Event } from "../../api/events";
 
+export type SearchFormData = {
+  date: string;
+};
+export type OnSearch = (data: SearchFormData) => void;
+
 // fetch の引数の url は path だけを指定しても勝手に origin を補完してくれる
 // see. https://github.github.io/fetch/#url
 const eventsApiEndpoint = "/api/events";
 
 export const Main = () => {
   const [events, setEvents] = useState<Event[]>([]);
-  const onSearch = (data: any) => {
+  const onSearch: OnSearch = data => {
     return console.log(data);
   };
 


### PR DESCRIPTION
## Overview

フォームの検索するボタンを押すと、console にフォームのデータが出力されるところまで。
useReducer で Input に入力されたデータを管理することで react-hook-form が捨てられた。
react-hook-form は handleSubmit 以外に toggle なども一緒にしようとすると辛かったので捨てられて良かった。